### PR TITLE
LESS_ARCTIC_TOWNS Improvements

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -336,7 +336,7 @@ void ARegion::SetupPop()
 			}
 		}
 
-		if (Globals->LESS_ARCTIC_TOWNS)
+		if (Globals->LESS_ARCTIC_TOWNS && zloc == 1)
 		{
 			const int dnorth = GetPoleDistance(D_NORTH);
 			const int dsouth = GetPoleDistance(D_SOUTH);

--- a/aregion.cpp
+++ b/aregion.cpp
@@ -338,14 +338,15 @@ void ARegion::SetupPop()
 
 		if (Globals->LESS_ARCTIC_TOWNS && zloc == 1)
 		{
+			const int arctic_zone_size = parentRegionArray->y / 10;
 			const int dnorth = GetPoleDistance(D_NORTH);
 			const int dsouth = GetPoleDistance(D_SOUTH);
 
-			if (dnorth < 9)
-				townch += 25 * (9 - dnorth) * (9 - dnorth) * Globals->LESS_ARCTIC_TOWNS;
+			if (dnorth < arctic_zone_size)
+				townch += 25 * (arctic_zone_size - dnorth) * (arctic_zone_size - dnorth) * Globals->LESS_ARCTIC_TOWNS;
 
-			if (dsouth < 9)
-				townch += 25 * (9 - dsouth) * (9 - dsouth) * Globals->LESS_ARCTIC_TOWNS;
+			if (dsouth < arctic_zone_size)
+				townch += 25 * (arctic_zone_size - dsouth) * (arctic_zone_size - dsouth) * Globals->LESS_ARCTIC_TOWNS;
 		}
 
 		int spread = Globals->TOWN_SPREAD;
@@ -921,8 +922,10 @@ int ARegion::GetPoleDistance(int dir)
 	return ct;
 }
 
-void ARegion::Setup()
+void ARegion::Setup(ARegionArray *pArr)
 {
+	parentRegionArray = pArr;
+	
 	// type and location have been setup, do everything else
 	SetupProds();
 
@@ -3879,7 +3882,7 @@ void ARegionList::FinalSetup(ARegionArray *pArr)
 					reg->wages = -1;
 			}
 
-			reg->Setup();
+			reg->Setup(pArr);
 		}
 	}
 }

--- a/aregion.h
+++ b/aregion.h
@@ -181,7 +181,7 @@ public:
 	/// destructor
 	~ARegion();
 
-	void Setup();
+	void Setup(ARegionArray *pArr);
 
 	void Writeout(Aoutfile *f);
 	void Readin(Ainfile *f, AList *facs, ATL_VER v);
@@ -366,6 +366,7 @@ public: // data
 	ProductionList products;
 	MarketList markets;
 	int xloc, yloc, zloc;
+	ARegionArray *parentRegionArray;
 };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Changed LESS_ARCTIC_TOWNS to only impact surface towns, as the Underworld has no concept of arctic and due to the lesser size is also over-impacted by this setting.

Added variable sized arctic zone for LESS_ARCTIC_TOWNS, rather than the hard-coded 9 hexes on both the North and South sides.  On smaller maps this setting can cover most or all of the world, which was likely unintentional.