### PR TITLE
 Skill-based Unit Maintenance Improvement

### DIFF
--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 3 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 4 )
 
 class OrdersCheck
 {

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -1751,12 +1751,9 @@ int Game::GenRules(const AString &rules, const AString &css,
 		} else {
 			temp += "All units ";
 		}
-		temp += "pay a fee based on the number of skill levels the character "
-			"has.  This fee is the maximum of $";
+		temp += "pay an additional fee based on the number of skill levels the character "
+			"has.  This fee is $";
 		temp += AString(Globals->MAINTENANCE_MULTIPLIER) + " per skill level";
-		temp += " and a cost of $";
-		temp += AString(Globals->MAINTENANCE_COST) + " for normal characters";
-		temp += AString(" or $") + Globals->LEADER_COST + " for leaders";
 		if(Globals->MULTIPLIER_USE != GameDefs::MULT_ALL) {
 			temp += ". All other characters pay a fee of ";
 			temp += Globals->MAINTENANCE_COST;

--- a/unit.cpp
+++ b/unit.cpp
@@ -1620,11 +1620,8 @@ int Unit::MaintCost()
 	int i = leaders * Globals->LEADER_COST;
 	if (Globals->MULTIPLIER_USE != GameDefs::MULT_NONE)
 	{
-		// higher leader cost: maintenance_multiplier * total skill points
-		const int multiI = leaders * SkillLevels() * Globals->MAINTENANCE_MULTIPLIER;
-
-		if (multiI > i)
-			i = multiI;
+		// Skill costs are in addtion to base LEADER_COST
+		i += leaders * SkillLevels() * Globals->MAINTENANCE_MULTIPLIER;
 	}
 
 	int retval = i;
@@ -1639,9 +1636,8 @@ int Unit::MaintCost()
 	i = nonleaders * Globals->MAINTENANCE_COST;
 	if (Globals->MULTIPLIER_USE == GameDefs::MULT_ALL)
 	{
-		const int multiI = nonleaders * SkillLevels() * Globals->MAINTENANCE_MULTIPLIER;
-		if (multiI > i)
-			i = multiI;
+		// Skill costs are in addtion to base MAINTENANCE_COST
+		i += nonleaders * SkillLevels() * Globals->MAINTENANCE_MULTIPLIER;			
 	}
 
 	retval += i;


### PR DESCRIPTION
Changed Skill-based maintenance to be base cost plus skill cost, rather than higher of the two.  This is more obvious to players and will allow for easier implementation of Hit-based maintenance.