### PR TITLE
Miskatonic Rulesset Update & Minor Gamedata Revision

### DIFF
--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 12 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 13 )
 
 class OrdersCheck
 {

--- a/gamedata.cpp
+++ b/gamedata.cpp
@@ -3820,7 +3820,7 @@ static ObjectType ot[] =
 	 I_STONE,10,S_BUILDING,1,
 	 5,1,2,
 	 -1,-1},
-	{"Fort",
+	{"Keep",
 	 ObjectType::CANENTER | ObjectType::CANMODIFY,
 	 75,0,0,20,
 	 I_STONE,40,S_BUILDING,2,

--- a/miskatonic/rules.cpp
+++ b/miskatonic/rules.cpp
@@ -56,7 +56,7 @@ int allowedTradesSize = sizeof(at) / sizeof(at[0]);
 
 static GameDefs g = {
 	"Miskatonic",				// RULESET_NAME
-	MAKE_ATL_VER( 1, 0, 1 ),    // RULESET_VERSION
+	MAKE_ATL_VER( 1, 0, 2 ),    // RULESET_VERSION
 
 	2, /* FOOT_SPEED */
 	4, /* HORSE_SPEED */
@@ -191,7 +191,7 @@ static GameDefs g = {
 	5,	// SKILL_PRACTISE_AMOUNT
 	0,	// UPKEEP_MINIMUM_FOOD
 	-1,	// UPKEEP_MAXIMUM_FOOD
-	30,	// UPKEEP_FOOD_VALUE
+	50,	// UPKEEP_FOOD_VALUE
 	1,	// PREVENT_SAIL_THROUGH
 	0,	// ALLOW_TRIVIAL_PORTAGE
 };


### PR DESCRIPTION
Miskatonic ruleset: Increased UPKEEP_FOOD_VALUE from 30 to 50.
Renamed the defensive building 'Fort' to 'Keep'.