### PR TITLE
Fix for spaces in description of moving on a road

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -2562,7 +2562,7 @@ int ARegion::MoveCost(int movetype, ARegion *fromRegion, int dir, AString *road)
 
 			// update move message
 			if (road)
-				*road = " on a road";
+				*road = "on a road ";
 		}
 	}
 

--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 30 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 31 )
 
 class OrdersCheck
 {


### PR DESCRIPTION
   (had two spaces before, none after)