### PR TITLE
Implemented alias renaming on repeating orders

### DIFF
--- a/alist.cpp
+++ b/alist.cpp
@@ -89,7 +89,7 @@ void AList::push_back(AListElem *e)
 	}
 }
 
-AListElem* AList::next(AListElem *e)
+AListElem* AList::next(AListElem *e) const
 {
 	return e ? e->next : 0;
 }

--- a/alist.h
+++ b/alist.h
@@ -58,8 +58,8 @@ public:
 	AListElem* get(AListElem *e);
 
 	///@return the element after 'e'
-	AListElem* Next(AListElem *e) { return next(e); }
-	AListElem* next(AListElem *e);
+	AListElem* Next(AListElem *e) const { return next(e); }
+	AListElem* next(AListElem *e) const;
 
 	///@return true if 'e' was in this (before being removed)
 	bool Remove(AListElem *e) { return remove(e); }

--- a/aregion.cpp
+++ b/aregion.cpp
@@ -1678,7 +1678,7 @@ Unit* ARegion::GetUnitAlias(int alias, int faction)
 	return NULL;
 }
 
-Unit* ARegion::GetUnitId(UnitId *id, int faction)
+Unit* ARegion::GetUnitId(const UnitId *id, int faction)
 {
 	forlist(&objects)
 	{
@@ -2344,7 +2344,8 @@ void ARegion::WriteTemplate(Areport *f, Faction *fac, ARegionList *pRegs, int mo
 
 			forlist(&(u->oldorders))
 			{
-				f->PutStr(*((AString*)elem));
+				Order *old_order = (Order*)elem;
+				f->PutStr(old_order->toString(this, fac->num));
 			}
 			u->oldorders.DeleteAll();
 

--- a/aregion.h
+++ b/aregion.h
@@ -218,7 +218,7 @@ public:
 	Unit* GetUnitAlias(int alias, int faction);
 
 	///@return unit matching 'id' for 'faction'
-	Unit* GetUnitId(UnitId *id, int faction);
+	Unit* GetUnitId(const UnitId *id, int faction);
 
 	///@return new Location wrapping id, faction, this
 	Location* GetLocation(UnitId *id, int faction);

--- a/game.cpp
+++ b/game.cpp
@@ -1045,9 +1045,9 @@ int Game::ReadPlayersLine(AString *pToken, AString *pLine, Faction *pFac,
 										"for faction "+pFac->num);
 							} else {
 								if(getatsign) {
-									u->oldorders.Add(new AString(saveorder));
+									u->oldorders.Add(new RawTextOrder(saveorder));
 								}
-								ProcessOrder(o, u, pLine, NULL);
+								ProcessOrder(o, u, pLine, NULL, 0);
 							}
 						}
 					}

--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 44 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 45 )
 
 class OrdersCheck
 {
@@ -305,8 +305,8 @@ private:
     int ParseDir(AString * token);
 
     void ParseOrders(int faction, Aorders *ordersFile, OrdersCheck *pCheck );
-    void ProcessOrder( int orderNum, Unit *unit, AString *order,
-                       OrdersCheck *pCheck );
+    Order* ProcessOrder( int orderNum, Unit *unit, AString *order,
+                       OrdersCheck *pCheck, int at_value );
     void ProcessMoveOrder(Unit *,AString *, OrdersCheck *pCheck );
     void ProcessAdvanceOrder(Unit *,AString *, OrdersCheck *pCheck );
     Unit *ProcessFormOrder( Unit *former, AString *order,
@@ -321,7 +321,7 @@ private:
 	void ProcessWithdrawOrder(Unit *,AString *, OrdersCheck *pCheck );
     void ProcessDeclareOrder(Faction *,AString *, OrdersCheck *pCheck );
     void ProcessStudyOrder(Unit *,AString *, OrdersCheck *pCheck );
-    void ProcessTeachOrder(Unit *,AString *, OrdersCheck *pCheck );
+    Order* ProcessTeachOrder(Unit *,AString *, OrdersCheck *pCheck, int at_value);
     void ProcessWorkOrder(Unit *, OrdersCheck *pCheck );
     void ProcessProduceOrder(Unit *,AString *, OrdersCheck *pCheck );
     void ProcessBuyOrder( Unit *, AString *, OrdersCheck *pCheck );

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -4247,6 +4247,7 @@ int Game::GenRules(const AString &rules, const AString &css,
 	temp2 = "FORGET Mining";
 	f.CommandExample(temp, temp2);
 
+	//-----
 	f.ClassTagText("DIV", "rule", "");
 	f.LinkRef("form");
 	f.TagText("H4", "FORM [alias]");
@@ -4271,16 +4272,25 @@ int Game::GenRules(const AString &rules, const AString &css,
 		"numbers).  The new unit can then be referred to as NEW <alias> in "
 		"place of the regular unit number.";
 	f.Paragraph(temp);
+
+	temp = AString("For recurring ") + f.Link("#teach", "TEACH") + " orders"
+		" (using '@'), you can use !NEW <alias> to get the new unit number."
+		" In other words, '@3 TEACH !NEW 1' will put '@2 TEACH 413' into"
+		" your orders template next turn.";
+	f.Paragraph(temp);
+
 	temp = "You can refer to newly created units belonging to other "
 		"factions, if you know what alias number they are, e.g. FACTION 15 "
 		"NEW 2 will refer to faction 15's newly created unit with alias 2.";
 	f.Paragraph(temp);
+
 	temp = "Note: If a unit moves out of the region in which it was formed "
 		"(by the ";
 	temp += f.Link("#move", "MOVE") + " order, or otherwise), the alias "
 		"will no longer work. This is to prevent conflicts with other units "
 		"that may have the same alias in other regions.";
 	f.Paragraph(temp);
+
 	temp = "If the demand for recruits in that region that month is much "
 		"higher than the supply, it may happen that the new unit does not "
 		"gain all the recruits you ordered it to buy, or it may not gain "
@@ -4290,6 +4300,7 @@ int Game::GenRules(const AString &rules, const AString &css,
 		"unit will be dissolved, and the silver and any other items it was "
 		"given will revert to the first unit you have in that region.";
 	f.Paragraph(temp);
+
 	f.Paragraph("Example:");
 	temp = "This set of orders for unit 17 would create two new units with "
 		"alias numbers 1 and 2, name them Merlin's Guards and Merlin's "
@@ -4300,6 +4311,7 @@ int Game::GenRules(const AString &rules, const AString &css,
 		"unit that created these two then pays them enough money (using the "
 		"NEW keyword to refer to them by alias numbers) to cover the costs "
 		"of recruitment and the month's maintenance.";
+
 	temp2 = "UNIT 17\n";
 	temp2 += "FORM 1\n";
 	temp2 += "    NAME UNIT \"Merlin's Guards\"\n";
@@ -4322,6 +4334,12 @@ int Game::GenRules(const AString &rules, const AString &css,
 	temp2 += "GIVE NEW 2 2000 silver\n";
 	f.CommandExample(temp,temp2);
 
+	temp = "Create a new squad of men each turn for training:";
+	temp2 = "@TURN\n  FORM 1\n    BUY 20 MEN\n    @3 STUDY COMB\n  END\n\n"
+		"  @3 TEACH !NEW 1\nENDTURN";
+	f.CommandExample(temp,temp2);
+
+	//-----
 	f.ClassTagText("DIV", "rule", "");
 	f.LinkRef("give");
 	f.TagText("H4", "GIVE [unit] [quantity] [item]");

--- a/object.cpp
+++ b/object.cpp
@@ -214,7 +214,7 @@ Unit* Object::GetUnitAlias(int alias, int faction)
 	return Unit::findByFaction(units, alias, faction);
 }
 
-Unit* Object::GetUnitId(UnitId *id, int faction)
+Unit* Object::GetUnitId(const UnitId *id, int faction)
 {
 	if (id == NULL)
 		return NULL;

--- a/object.h
+++ b/object.h
@@ -115,7 +115,7 @@ public:
 	Unit* GetUnitAlias(int alias, int faction);
 
 	///@return unit according to 'id'
-	Unit* GetUnitId(UnitId *id, int faction);
+	Unit* GetUnitId(const UnitId *id, int faction);
 
 	///@return 1 if this is a road, else 0
 	int IsRoad();

--- a/orders.cpp
+++ b/orders.cpp
@@ -104,11 +104,26 @@ int Parse1Order(AString *token)
 
 Order::Order(int o)
 : type(o)
+, repeat(0)
 {
 }
 
 Order::~Order()
 {
+}
+
+AString Order::repeatPrefix() const
+{
+	AString ret("@");
+	if (repeat == -1)
+		return ret;
+
+	if (repeat <= 2)
+		return "";
+
+	ret += AString(repeat - 1);
+	ret += " ";
+	return ret;
 }
 
 ExchangeOrder::ExchangeOrder()
@@ -187,6 +202,24 @@ TeachOrder::TeachOrder()
 
 TeachOrder::~TeachOrder()
 {
+}
+
+AString TeachOrder::toString(ARegion *region, int fac_num) const
+{
+	if (repeat == 0 || repeat == 1)
+		return AString();
+
+	AString ret = repeatPrefix();
+	ret += "teach";
+
+	forlist(&targets)
+	{
+		UnitId *id = (UnitId*)elem;
+		ret += " ";
+		ret += id->Print(region, fac_num);
+	}
+
+	return ret;
 }
 
 ProduceOrder::ProduceOrder()

--- a/orders.h
+++ b/orders.h
@@ -25,8 +25,9 @@
 //
 // END A3HEADER
 #include "alist.h"
+#include "astring.h"
 #include <deque>
-class AString;
+class ARegion;
 class UnitId;
 
 //----------------------------------------------------------------------------
@@ -134,7 +135,26 @@ public:
 	explicit Order(int t);
 	virtual ~Order();
 
+	virtual AString toString(ARegion*, int fac_num) const { return ""; }
+
+	AString repeatPrefix() const;
+
 	const int type;
+	int repeat;
+};
+
+class RawTextOrder : public Order
+{
+public:
+	explicit RawTextOrder(const AString &t)
+	: Order(NORDERS)
+	, t_(t)
+	{
+	}
+
+	virtual AString toString(ARegion*, int fac_num) const { return t_; }
+
+	const AString t_;
 };
 
 /// Move to adjacent hex or enter/leave an object
@@ -190,6 +210,8 @@ class TeachOrder : public Order
 public:
 	TeachOrder();
 	~TeachOrder();
+
+	virtual AString toString(ARegion *region, int fac_num) const;
 
 	AList targets;
 };

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -2225,7 +2225,7 @@ void Game::DoExchangeOrder(ARegion * r,Unit * u,ExchangeOrder * o)
 	Unit *t = r->GetUnitId(o->target,u->faction->num);
 	if (!t) {
 		u->Error(AString("EXCHANGE: Nonexistant target (") +
-				o->target->Print() + ").");
+				o->target->Print(NULL) + ").");
 		u->exchangeorders.Remove(o);
 		return;
 	}
@@ -2260,7 +2260,7 @@ void Game::DoExchangeOrder(ARegion * r,Unit * u,ExchangeOrder * o)
 	// New RULE -- Must be able to see unit to give something to them!
 	if(!u->CanSee(r, t)) {
 		u->Error(AString("EXCHANGE: Nonexistant target (") +
-				o->target->Print() + ").");
+				o->target->Print(NULL) + ").");
 		return;
 	}
 	// Check other unit has enough to give
@@ -2350,7 +2350,7 @@ void Game::DoExchangeOrder(ARegion * r,Unit * u,ExchangeOrder * o)
 	if (!exchangeOrderFound) {
 		if(!u->CanSee(r, t)) {
 			u->Error(AString("EXCHANGE: Nonexistant target (") +
-					o->target->Print() + ").");
+					o->target->Print(NULL) + ").");
 			u->exchangeorders.Remove(o);
 			return;
 		} else {
@@ -2423,7 +2423,7 @@ int Game::DoGiveOrder(ARegion * r,Unit * u,GiveOrder * o)
 
 	Unit * t = r->GetUnitId(o->target,u->faction->num);
 	if (!t) {
-		u->Event(AString("GIVE: Nonexistant target (") + o->target->Print() + ").");
+		u->Event(AString("GIVE: Nonexistant target (") + o->target->Print(NULL) + ").");
 		return 0;
 	}
 
@@ -2436,7 +2436,7 @@ int Game::DoGiveOrder(ARegion * r,Unit * u,GiveOrder * o)
 	// New RULE -- Must be able to see unit to give something to them!
 	if(!u->CanSee(r, t) &&
 			(t->faction->GetAttitude(u->faction->num) < A_FRIENDLY)) {
-		u->Error(AString("GIVE: Nonexistant target (") + o->target->Print() +
+		u->Error(AString("GIVE: Nonexistant target (") + o->target->Print(NULL) +
 				").");
 		return 0;
 	}

--- a/unit.cpp
+++ b/unit.cpp
@@ -40,10 +40,11 @@ UnitId::UnitId(bool)
 {
 }
 
-UnitId::UnitId(int unit_num, int alias, int faction)
+UnitId::UnitId(int unit_num, int alias, int faction, bool r)
 : unitnum(unit_num)
 , alias  (alias)
 , faction(faction)
+, rename(r)
 {
 	if (unit_num < 0)
 	{
@@ -66,7 +67,7 @@ UnitId::~UnitId()
 {
 }
 
-AString UnitId::Print() const
+AString UnitId::Print(ARegion *region, int fac_num) const
 {
 	if (unitnum)
 		return AString(unitnum);
@@ -75,6 +76,13 @@ AString UnitId::Print() const
 	{
 		return AString("faction ") + AString(faction) + " new " +
 		   AString(alias);
+	}
+
+	if (region && rename)
+	{
+		Unit *u = region->GetUnitId(this, fac_num);
+		if (u)
+			return AString(u->num);
 	}
 
 	return AString("new ") + AString(alias);

--- a/unit.h
+++ b/unit.h
@@ -108,10 +108,10 @@ class UnitId : public AListElem
 {
 public:
 	UnitId(bool nobody);
-	UnitId(int unit_num, int alias = 0, int faction = 0);
+	UnitId(int unit_num, int alias = 0, int faction = 0, bool rename = false);
 	~UnitId();
 
-	AString Print() const;
+	AString Print(ARegion *region, int fac_num = 0) const;
 
 	///@return true if unitnum does not refer to "no one"
 	bool valid() const { return unitnum != -1; }
@@ -123,6 +123,7 @@ private: // data
 	int unitnum; ///< 0 -> new unit
 	int alias;   ///< "new alias"
 	int faction; ///< "faction F new alias"
+	bool rename; ///< write out with new unit number
 };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
   Use "!new" to get a rename

   E.g. "@3 teach !new 1" will become "@2 teach 123" the next turn

   Currently only on "teach"

Added some const