### PR TITLE
Miskatonic 2 Rules Changes

### DIFF
--- a/aregion.cpp
+++ b/aregion.cpp
@@ -4017,7 +4017,7 @@ void ARegionList::InitSetupGates(int level)
 
 	ARegionArray *pArr = pRegionArrays[level];
 
-	for (int i = 0; i < pArr->x / 8; ++i)
+	for (int i = 0; i < pArr->x / 4; ++i)
 	{
 		for (int j = 0; j < pArr->y / 16; ++j)
 		{

--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 48 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 49 )
 
 class OrdersCheck
 {

--- a/gamedata.h
+++ b/gamedata.h
@@ -28,6 +28,7 @@
 /// All the items in the game
 enum ItemDef
 {
+	I_FACTIONLEADER,
 	I_LEADERS,
 	I_VIKING,
 	I_BARBARIAN,
@@ -203,6 +204,8 @@ enum ItemDef
 	// Generic processed food
 	I_FOOD,
 	// Additional items for Miskatonic
+	I_PONY,
+	I_MBOAR,
 	// Races
 	I_HIGHELF,
 	I_WOODELF,
@@ -344,6 +347,7 @@ enum ItemDef
 enum ManDef
 {
 	MAN_NONE,
+	MAN_FLEADER,
 	MAN_LEADER,
 	MAN_VIKING,
 	MAN_BARBARIAN,
@@ -609,8 +613,10 @@ enum MountDef
 	MOUNT_NONE,
 	MOUNT_WHORSE,
 	MOUNT_HORSE,
+	MOUNT_PONY,
 	MOUNT_CAMEL,
 	MOUNT_MWOLF,
+	MOUNT_BOAR,
 	MOUNT_MSPIDER,
 	MOUNT_MOLE,
 	NUMMOUNTS

--- a/miskatonic/extra.cpp
+++ b/miskatonic/extra.cpp
@@ -46,80 +46,91 @@ int Game::SetupFaction( Faction *pFac )
 	}
 
 	// Setup Faction Leader
-    Unit *leader = GetNewUnit( pFac );
+    Unit *faction_leader = GetNewUnit(pFac);
 
-    leader->SetMen( I_LEADERS, 1 );
-	pFac->DiscoverItem(I_LEADERS, 0, 1);
+    faction_leader->SetMen(I_FACTIONLEADER, 1);
+	pFac->DiscoverItem(I_FACTIONLEADER, 0, 1);
 
 	// Flags
-    leader->reveal = REVEAL_FACTION;
-	leader->SetFlag(FLAG_BEHIND,1);
+    faction_leader->reveal = REVEAL_FACTION;
+	faction_leader->SetFlag(FLAG_BEHIND,1);
 
 	// Skills
-    leader->type = U_MAGE;
-    leader->Study(S_PATTERN, 30);
-    leader->Study(S_SPIRIT, 30);
-	leader->Study(S_FORCE, 30);
-	leader->Study(S_FIRE, 30);
-	leader->Study(S_COMBAT, 30);
-	leader->Study(S_TACTICS, 30);
-	leader->Study(S_GATE_LORE, 30);
+    faction_leader->type = U_MAGE;
+    faction_leader->Study(S_PATTERN, 30);
+    faction_leader->Study(S_SPIRIT, 30);
+	faction_leader->Study(S_FORCE, 30);
+	// faction_leader->Study(S_FIRE, 30);
+	// faction_leader->Study(S_COMBAT, 30);
+	// faction_leader->Study(S_TACTICS, 30);
+	faction_leader->Study(S_GATE_LORE, 30);
 
 	// Set combat spell
-	leader->combat = S_FIRE;
+	// faction_leader->combat = S_FIRE;
 
 	// Special wizard items
-	leader->items.SetNum(I_WIZARDSTAFF, 1);
+	faction_leader->items.SetNum(I_WIZARDSTAFF, 1);
 	pFac->DiscoverItem(I_WIZARDSTAFF, 0, 1);
-	leader->items.SetNum(I_WIZROBE, 1);
+	faction_leader->items.SetNum(I_WIZROBE, 1);
 	pFac->DiscoverItem(I_WIZROBE, 0, 1);
 
 	// Horses too heavy for base GATE LORE skill
 	if (!Globals->NEXUS_NO_EXITS) {
-		leader->items.SetNum(I_HORSE, 1);
+		faction_leader->items.SetNum(I_HORSE, 1);
 		pFac->DiscoverItem(I_HORSE, 0, 1);
 	}
 
 	if(TurnNumber() >= 24) {
-		leader->Study(S_PATTERN, 60);
-		leader->Study(S_SPIRIT, 60);
-		leader->Study(S_FORCE, 90);
-		leader->Study(S_EARTH_LORE, 30);
-		leader->Study(S_STEALTH, 30);
-		leader->Study(S_OBSERVATION, 30);
+		faction_leader->Study(S_PATTERN, 60);
+		faction_leader->Study(S_SPIRIT, 60);
+		faction_leader->Study(S_FORCE, 90);
+		faction_leader->Study(S_EARTH_LORE, 30);
+		faction_leader->Study(S_STEALTH, 30);
+		faction_leader->Study(S_OBSERVATION, 30);
 	}
 	if(TurnNumber() >= 36) {
-		leader->Study(S_TACTICS, 90);
-		leader->Study(S_COMBAT, 60);
+		faction_leader->Study(S_TACTICS, 90);
+		faction_leader->Study(S_COMBAT, 60);
 	}
 
 	if (Globals->UPKEEP_MINIMUM_FOOD > 0)
 	{
 		if (!(ItemDefs[I_FOOD].flags & ItemType::DISABLED))
 		{
-			leader->items.SetNum(I_FOOD, 6);
+			faction_leader->items.SetNum(I_FOOD, 6);
 			pFac->DiscoverItem(I_FOOD, 0, 1);
 		}
 		else if (!(ItemDefs[I_FISH].flags & ItemType::DISABLED))
 		{
-			leader->items.SetNum(I_FISH, 6);
+			faction_leader->items.SetNum(I_FISH, 6);
 			pFac->DiscoverItem(I_FISH, 0, 1);
 		}
 		else if (!(ItemDefs[I_LIVESTOCK].flags & ItemType::DISABLED))
 		{
-			leader->items.SetNum(I_LIVESTOCK, 6);
+			faction_leader->items.SetNum(I_LIVESTOCK, 6);
 			pFac->DiscoverItem(I_LIVESTOCK, 0, 1);
 		}
 		else if (!(ItemDefs[I_GRAIN].flags & ItemType::DISABLED))
 		{
-			leader->items.SetNum(I_GRAIN, 2);
+			faction_leader->items.SetNum(I_GRAIN, 2);
 			pFac->DiscoverItem(I_GRAIN, 0, 1);
 		}
-		leader->items.SetNum(I_SILVER, 10);
+		faction_leader->items.SetNum(I_SILVER, 10);
 		pFac->DiscoverItem(I_SILVER, 0, 1);
 	}
 
-	leader->MoveUnit( reg->GetDummy() );
+	faction_leader->MoveUnit(reg->GetDummy());
+
+	Unit *leaders = GetNewUnit( pFac );
+
+    leaders->SetMen(I_LEADERS, 2);
+	pFac->DiscoverItem(I_LEADERS, 0, 1);
+
+	// Flags
+    leaders->reveal = REVEAL_FACTION;
+	leaders->SetFlag(FLAG_BEHIND,1);
+
+	leaders->MoveUnit(reg->GetDummy());
 
     return( 1 );
 }
@@ -301,10 +312,6 @@ void Game::ModifyTablesPerRuleset(void)
 	EnableItem(I_ELONGBOW);
 	EnableItem(I_ECROSSBOW);
 	EnableItem(I_EHEAVYCROSSBOW);
-
-	// Flaming Sword
-	EnableItem(I_FSWORD);
-	EnableSkill(S_CREATE_FLAMING_SWORD);
 
 	// Special Leader Items
 	EnableItem(I_WIZARDSTAFF);

--- a/miskatonic/gamedata.cpp
+++ b/miskatonic/gamedata.cpp
@@ -68,6 +68,14 @@
 
 ItemType id[] =
 {
+	{"faction leader", "faction leaders", "FLEAD",
+	 0,
+	 -1,0,0,0, {{-1,0},{-1,0},{-1,0},{-1,0}},
+	 -1,0,0, {{-1,0},{-1,0},{-1,0},{-1,0}},
+	 10, IT_MAN, 100, 1, MAN_FLEADER, 0,
+	 25,0,0,0,
+	 {{-1,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}},
+	 -1,0},
 	{"leader", "leaders", "LEAD",
 	 0,
 	 -1,0,0,0, {{-1,0},{-1,0},{-1,0},{-1,0}},
@@ -1338,7 +1346,7 @@ ItemType id[] =
 	 S_MONSTERTRAINING,1,2,1, {{-1,0}, {-1,0},{-1,0},{-1,0}},
 	 -1,0,0, {{-1,0},{-1,0},{-1,0},{-1,0}},
 	 10, IT_ADVANCED | IT_MOUNT , 30,1,MOUNT_MWOLF, 0,
-	 17,17,0,0,
+	 19,19,0,0,
 	 {{-1,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}},
 	 I_LASSO,1},
 	{"giant spider","giant spiders","MSPI",
@@ -1438,6 +1446,22 @@ ItemType id[] =
 	 {{-1,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}},
 	 -1,0},
 	// Additional items for Miskatonic
+	{"pony","ponies","PONY",
+	 0,
+	 S_HORSETRAINING,1,1,1, {{-1,0}, {-1,0},{-1,0},{-1,0}},
+	 -1,0,0, {{-1,0},{-1,0},{-1,0},{-1,0}},
+	 25, IT_NORMAL | IT_MOUNT, 30,1,MOUNT_PONY, 0,
+	 40,40,0,0,
+	 {{-1,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}},
+	 I_LASSO,1},
+	{"giant boar","giant boars","MBOAR",
+	 ItemType::NOMARKET,
+	 S_MONSTERTRAINING,2,2,1, {{-1,0}, {-1,0},{-1,0},{-1,0}},
+	 -1,0,0, {{-1,0},{-1,0},{-1,0},{-1,0}},
+	 40, IT_ADVANCED | IT_MOUNT , 30,1,MOUNT_BOAR, 0,
+	 55,55,0,0,
+	 {{-1,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}},
+	 I_LASSO,1},
 	{"high elf","high elves","HELF",
 	 0,
 	 -1,0,0,0, {{-1,0}, {-1,0},{-1,0},{-1,0}},
@@ -2448,7 +2472,6 @@ ItemType id[] =
 	 0,0,0,0,
 	 {{-1,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}},
 	 -1,0},
-
 };
 ItemType * ItemDefs = id;
 
@@ -2461,7 +2484,8 @@ ManType mt[] = {
 	// 1st skill, 2nd, 3rd, 4th, 5th, 6th, hits, alignment
 	//
 	{0,0,0,0,{-1,-1,-1,-1,-1,-1}, 1, ManType::NEUTRAL},//NONE
-	{-1,5,5,5,{-1,-1,-1,-1,-1,-1}, 10, ManType::NEUTRAL},//LEADER
+	{-1,5,5,5,{-1,-1,-1,-1,-1,-1}, 10, ManType::NEUTRAL},//FLEADER
+	{-1,5,5,5,{-1,-1,-1,-1,-1,-1}, 5, ManType::NEUTRAL},//LEADER
 	{1,3,2,4,{S_SHIPBUILDING,S_SAILING,S_LUMBERJACK,S_COMBAT,-1,-1}, 1, ManType::NEUTRAL},//VIKING
 	{1,3,2,4,{S_MINING,S_HUNTING,S_WEAPONSMITH,S_COMBAT,-1,-1}, 1, ManType::NEUTRAL},//BARBARIAN
 	{1,3,2,4,{S_HORSETRAINING,S_FARMING,S_CARPENTER,S_ENTERTAINMENT,S_COOKING,-1}, 1, ManType::NEUTRAL},//PLAINSMAN
@@ -2484,7 +2508,7 @@ ManType mt[] = {
 	{1,3,2,4,{S_COMBAT,S_WEAPONSMITH,-1,-1,-1,-1}, 1, ManType::NEUTRAL},//MOUNTAINMAN
 	// Additional Races for Miskatonic
 	{3,5,3,4,{S_LONGBOW,S_FARMING,S_HORSETRAINING,S_HEALING,-1,-1}, 2, ManType::GOOD},// HIGHELF
-	{1,5,3,4,{S_LONGBOW,S_LUMBERJACK,S_HUNTING,-1,-1,-1}, 2, ManType::GOOD},// WOODELF
+	{1,5,3,4,{S_LONGBOW,S_LUMBERJACK,S_HUNTING,S_MONSTERTRAINING,-1,-1}, 2, ManType::GOOD},// WOODELF
 	{2,5,3,4,{S_CROSSBOW,S_QUARRYING,S_BUILDING,-1,-1,-1}, 2, ManType::GOOD},// HILLDWARF
 	{2,5,3,4,{S_FARMING,S_RANCHING,-1,-1,-1,-1}, 1, ManType::GOOD},// HALFLING
 	{1,5,2,3,{S_COMBAT,S_RANCHING,S_HORSETRAINING,-1,-1,-1}, 3, ManType::GOOD},// CENTAUR
@@ -2492,11 +2516,11 @@ ManType mt[] = {
 	{2,5,3,4,{S_CARPENTER,S_ENTERTAINMENT,S_BUILDING,-1,-1,-1}, 1, ManType::GOOD},// GNOME
 	{2,5,3,4,{S_LONGBOW,S_WEAPONSMITH,-1,-1,-1,-1}, 2, ManType::GOOD},// GREYELF
 	{2,5,3,4,{S_FARMING,S_CARPENTER,S_HORSETRAINING,S_RIDING,S_SHIPBUILDING,-1}, 2, ManType::NEUTRAL},// HUMAN
-	{1,5,3,4,{S_LUMBERJACK,S_RANCHING,S_HUNTING,S_HERBLORE,-1,-1}, 2, ManType::NEUTRAL},// LIZARDMAN
+	{1,5,3,4,{S_LUMBERJACK,S_FISHING,S_HERBLORE,-1,-1,-1}, 2, ManType::NEUTRAL},// LIZARDMAN
 	{1,5,3,4,{S_COMBAT,S_RANCHING,S_MONSTERTRAINING,-1,-1,-1}, 2, ManType::NEUTRAL},// HALFORC
 	{1,5,2,3,{S_COMBAT,S_WEAPONSMITH,-1,-1,-1,-1}, 3, ManType::EVIL},// MINOTAUR
 	{1,5,3,4,{S_COMBAT,S_LUMBERJACK,S_MONSTERTRAINING,-1,-1,-1}, 2, ManType::EVIL},// ORC
-	{2,5,3,4,{S_COMBAT,S_WEAPONSMITH,S_ARMORER,S_BUILDING,-1,-1}, 2, ManType::EVIL},// HOBGOBLIN
+	{2,5,3,4,{S_COMBAT,S_MINING,S_ARMORER,S_BUILDING,-1,-1}, 2, ManType::EVIL},// HOBGOBLIN
 	{1,5,3,4,{S_COMBAT,S_QUARRYING,S_HUNTING,-1,-1,-1}, 2, ManType::EVIL},// GNOLL
 	{1,5,2,3,{S_COMBAT,-1,-1,-1,-1,-1}, 3, ManType::EVIL},// OGRE
 	{1,5,3,4,{S_CROSSBOW,S_MONSTERTRAINING,-1,-1,-1,-1}, 1, ManType::EVIL},// GOBLIN
@@ -3240,10 +3264,10 @@ WeaponType wepd[] = {
 	 4, 0, 0},
 
 	// WEAPON_WIZSTAFF
-	{WeaponType::LONG | WeaponType::ALWAYSREADY,
+	{WeaponType::LONG,
 	 -1, -1,
 	 CRUSHING, ATTACK_COMBAT, 1,
-	 4, 4, 1},
+	 2, 4, 1},
 
 };
 
@@ -3339,7 +3363,7 @@ ArmorType armd[] = {
 	// ARMOR_EAPLATE
 	{ 0, 100, {95, 95, 90, 95, 90, 66, 66, 66}},
 	// ARMOR_WIZROBE
-	{ ArmorType::USEINASSASSINATE, 100, {10, 10, 10, 10, 0, 50, 50, 50}},
+	{ ArmorType::USEINASSASSINATE, 100, {10, 10, 10, 10, 0, 25, 25, 25}},
 };
 
 ArmorType *ArmorDefs = armd;
@@ -3355,9 +3379,13 @@ MountType mountd[] = {
 	{S_RIDING, 3, 5, 3, -1, 0},
 	// MOUNT_HORSE
 	{S_RIDING, 1, 3, 3, -1, 0},
+	// MOUNT_PONY
+	{S_RIDING, 1, 2, 2, -1, 0},
 	// MOUNT_CAMEL
 	{S_RIDING, 1, 2, 2, SPECIAL_CAMEL_FEAR, 3},
 	// MOUNT_MWOLF
+	{S_RIDING, 1, 2, 2, -1, 0},
+	// MOUNT_BOAR
 	{S_RIDING, 1, 3, 3, -1, 0},
 	// MOUNT_SPIDER
 	{S_RIDING, 2, 4, 4, -1, 0},
@@ -4205,7 +4233,7 @@ static TerrainType td[] = {
 	//
 	// name, similar_type, flags,
 	// pop, wages, economy, movepoints,
-	// product array
+	// product array (product, chance, amount)
 	// normal races array
 	// coastal races array
 	// wmonfreq, smallmon, bigmon, humanoid,
@@ -4347,7 +4375,7 @@ static TerrainType td[] = {
 	 //R_CERAN_PLAIN2
 	{"plain", R_PLAIN, TerrainType::RIDINGMOUNTS | TerrainType::FLYINGMOUNTS,
 	 750,14,35,1,
-	 {{I_HORSE,100,20},{I_WHORSE,5,5},{I_ROOTSTONE,5,4},{I_WOOD,10,4},
+	 {{I_HORSE,90,20},{I_WHORSE,5,5},{I_ROOTSTONE,5,4},{I_WOOD,10,4},
 	  {-1,0,0},{-1,0,0},{-1,0,0}},
 	 {I_HUMAN,I_HIGHELF,I_GNOME,-1},
 	 {I_HALFLING,-1,-1},
@@ -4356,8 +4384,8 @@ static TerrainType td[] = {
 	 //R_CERAN_PLAIN3
 	{"plain", R_PLAIN, TerrainType::RIDINGMOUNTS | TerrainType::FLYINGMOUNTS,
 	 700,13,30,1,
-	 {{I_HORSE,100,20},{I_WHORSE,5,5},{I_IRON,10,4},{I_MITHRIL,5,3},
-	  {-1,0,0},{-1,0,0},{-1,0,0}},
+	 {{I_PONY,50,20},{I_WHORSE,5,5},{I_IRON,10,4},{I_MITHRIL,5,3},
+	  {I_MWOLF,15,5},{-1,0,0},{-1,0,0}},
 	 {I_HUMAN,I_HIGHELF,I_HALFLING,-1},
 	 {I_GOBLINMAN,I_HOBGOBLIN,-1},
 	 1,I_LION,I_RAT,I_CENTAUR,
@@ -4366,7 +4394,7 @@ static TerrainType td[] = {
 	{"forest", R_FOREST, TerrainType::FLYINGMOUNTS,
 	 400,12,20,2,
 	 {{I_WOOD,100,20},{I_FUR,100,10},{I_HERBS,100,10},{I_IRONWOOD,25,5},
-	  {I_YEW,25,5},{I_MWOLF,10,5},{I_STONE,10,4}},
+	  {I_YEW,25,5},{I_MWOLF,15,5},{I_STONE,10,4}},
 	 {I_WOODELF,I_GOBLINMAN,-1,-1},
 	 {I_HIGHELF,-1,-1},
 	 2,I_WOLF,I_TRENT,I_KOBOLD,
@@ -4375,7 +4403,7 @@ static TerrainType td[] = {
 	{"forest", R_FOREST, TerrainType::FLYINGMOUNTS,
 	 400,12,20,2,
 	 {{I_WOOD,100,20},{I_FUR,100,10},{I_HERBS,100,10},{I_IRONWOOD,25,5},
-	  {I_YEW,25,5},{I_MWOLF,5,5},{-1,0,0}},
+	  {I_YEW,25,5},{I_MWOLF,15,5},{-1,0,0}},
 	 {I_WOODELF,-1,-1,-1},
 	 {I_HIGHELF,-1,-1},
 	 2,I_WOLF,I_TRENT,I_KOBOLD,
@@ -4384,7 +4412,7 @@ static TerrainType td[] = {
 	{"forest", R_FOREST, TerrainType::FLYINGMOUNTS,
 	 400,12,20,2,
 	 {{I_WOOD,100,20},{I_FUR,100,10},{I_HERBS,100,10},{I_IRONWOOD,25,5},
-	  {I_YEW,25,5},{I_MWOLF,10,5},{I_MUSHROOM,10,10}},
+	  {I_YEW,25,5},{I_MBOAR,25,5},{I_MUSHROOM,10,10}},
 	 {I_WOODELF,I_GNOLL,-1,-1},
 	 {I_HIGHELF,I_HUMAN,-1},
 	 8,I_WOLF,I_TRENT,I_KOBOLD,
@@ -4429,7 +4457,7 @@ static TerrainType td[] = {
 	{"mountain", R_MOUNTAIN, TerrainType::FLYINGMOUNTS,
 	 400,12,20,2,
 	 {{I_IRON,100,20},{I_STONE,100,10},{I_MITHRIL,25,5},{I_ROOTSTONE,25,5},
-	  {I_ADMANTIUM,5,5},{I_MWOLF,10,10},{I_WOOD,10,4}},
+	  {I_ADMANTIUM,5,5},{I_PONY,50,15},{I_WOOD,10,4}},
 	 {I_MOUNTAINDWARF,I_ORC,I_OGREMAN,-1},
 	 {I_HOBGOBLIN,-1,-1},
 	 2,I_GBEAR,I_ROC,I_OGRE,
@@ -4438,7 +4466,7 @@ static TerrainType td[] = {
 	{"mountain", R_MOUNTAIN, TerrainType::FLYINGMOUNTS,
 	 500,12,20,2,
 	 {{I_IRON,100,20},{I_STONE,100,10},{I_MITHRIL,25,5},{I_ROOTSTONE,25,5},
-	  {I_ADMANTIUM,5,5},{I_MWOLF,10,10},{-1,0,0}},
+	  {I_ADMANTIUM,5,5},{I_MWOLF,10,10},{I_PONY,30,20}},
 	 {I_MOUNTAINDWARF,I_ORC,-1,-1},
 	 {I_GOBLINMAN,-1,-1},
 	 4,I_GBEAR,I_ROC,I_OGRE,
@@ -4447,8 +4475,8 @@ static TerrainType td[] = {
 	{"hill", R_CERAN_HILL, TerrainType::FLYINGMOUNTS,
 	 400,12,20,2,
 	 {{I_IRON,80,15},{I_STONE,100,30},{I_MITHRIL,10,5},{I_ROOTSTONE,25,5},
-	  {I_HERBS,10,10},{I_MWOLF,15,20},{-1,0,0}},
-	 {I_HOBGOBLIN,I_ORC,I_OGREMAN,-1},
+	  {I_HERBS,10,10},{I_MWOLF,25,20},{I_PONY,30,20}},
+	 {I_HOBGOBLIN,I_ORC,I_OGREMAN,I_HILLDWARF},
 	 {I_GOBLINMAN,I_GNOME,-1},
 	 2,I_GBEAR,I_ROC,I_OGRE,
 	 12,{O_LAIR,O_RUIN,O_CAVE,O_CRYPT,O_MAGETOWER,-1}},
@@ -4456,7 +4484,7 @@ static TerrainType td[] = {
 	{"hill", R_CERAN_HILL, TerrainType::FLYINGMOUNTS,
 	 400,12,20,2,
 	 {{I_IRON,80,15},{I_STONE,100,30},{I_MITHRIL,10,5},{I_ROOTSTONE,25,5},
-	  {I_HERBS,10,6},{I_MWOLF,10,20},{-1,0,0}},
+	  {I_HERBS,10,6},{I_MWOLF,10,20},{I_MBOAR,20,15}},
 	 {I_HOBGOBLIN,I_ORC,I_GNOME,I_HILLDWARF},
 	 {I_HALFLING,I_HUMAN,-1},
 	 2,I_GBEAR,I_ROC,I_OGRE,

--- a/miskatonic/rules.cpp
+++ b/miskatonic/rules.cpp
@@ -46,17 +46,17 @@ static int aa[] = { 3, 3, 3, 3, 3, 3, 3 };
 int *allowedApprentices = aa;
 int allowedApprenticesSize = sizeof(aa) / sizeof(aa[0]);
 
-static int aw[] = { 100, 100, 100, 100, 100, 100 };
+static int aw[] = { 25, 25, 25, 25, 25, 25 };
 int *allowedTaxes = aw;
 int allowedTaxesSize = sizeof(aw) / sizeof(aw[0]);
 
-static int at[] = { 100, 100, 100, 100, 100, 100 };
+static int at[] = { 25, 25, 25, 25, 25, 25 };
 int *allowedTrades = at;
 int allowedTradesSize = sizeof(at) / sizeof(at[0]);
 
 static GameDefs g = {
 	"Miskatonic",				// RULESET_NAME
-	MAKE_ATL_VER( 1, 0, 19 ),   // RULESET_VERSION
+	MAKE_ATL_VER( 1, 0, 20 ),   // RULESET_VERSION
 
 	2, /* FOOT_SPEED */
 	4, /* HORSE_SPEED */
@@ -89,8 +89,8 @@ static GameDefs g = {
 	50, /* GUARD_MONEY */
 	4000, /* CITY_POP */
 
-	20, /* WMON_FREQUENCY */
-	10, /* LAIR_FREQUENCY */
+	15, /* WMON_FREQUENCY */
+	5, /* LAIR_FREQUENCY */
 
 	0, /* FACTION_POINTS */
 
@@ -106,7 +106,7 @@ static GameDefs g = {
 	1, // CITY_MONSTERS_EXIST
 	1, // WANDERING_MONSTERS_EXIST
 	1, // LAIR_MONSTERS_EXIST
-	0, // WEATHER_EXISTS
+	1, // WEATHER_EXISTS
 	1, // OPEN_ENDED
 	0, // NEXUS_EXISTS
 	0, // CONQUEST_GAME
@@ -128,7 +128,7 @@ static GameDefs g = {
 
 	1, // DEFAULT_WORK_ORDER
 
-	GameDefs::FACLIM_MAGE_COUNT, // FACTION_LIMIT_TYPE
+	GameDefs::FACLIM_FACTION_TYPES, // FACTION_LIMIT_TYPE
 
 	GameDefs::WFLIGHT_MUST_LAND,	// FLIGHT_OVER_WATER
 	1, // NO_SWIM_TO_SEA
@@ -147,12 +147,12 @@ static GameDefs g = {
 	1, // NEXUS_NO_EXITS
 	1,	// BATTLE_FACTION_INFO
 	0,	// ALLOW_WITHDRAW
-	2500,	// CITY_RENAME_COST
+	5000,	// CITY_RENAME_COST
 	1,	// TAX_PILLAGE_MONTH_LONG
 	0,	// MULTI_HEX_NEXUS
 	1,	// UNDERWORLD_LEVELS
 	1,	// UNDERDEEP_LEVELS
-	0,	// ABYSS_LEVEL
+	1,	// ABYSS_LEVEL
 	80,	// TOWN_PROBABILITY
 	35,	// UNDERWORLD_TOWN_PROBABILITY
 	75,	// TOWN_SPREAD
@@ -178,9 +178,9 @@ static GameDefs g = {
 	1,	// PROPORTIONAL_AMTS_USAGE
 	1,  // USE_WEAPON_ARMOR_COMMAND
 	1,  // WMONSTER_SPOILS_RECOVERY
-	3,  // MONSTER_NO_SPOILS
-	9,  // MONSTER_SPOILS_RECOVERY
-	2,  // MAX_ASSASSIN_FREE_ATTACKS
+	4,  // MONSTER_NO_SPOILS
+	12, // MONSTER_SPOILS_RECOVERY
+	1,  // MAX_ASSASSIN_FREE_ATTACKS
 	1,  // RELEASE_MONSTERS
 	1,  // CHECK_MONSTER_CONTROL_MID_TURN
 	0,  // DETECT_GATE_NUMBERS

--- a/unit.cpp
+++ b/unit.cpp
@@ -1623,6 +1623,7 @@ int Unit::MaintCost()
 
 	// handle leaders
 	int leaders = GetMen(I_LEADERS);
+	leaders += GetMen(I_FACTIONLEADER);
 	if (leaders < 0)
 		leaders = 0;
 
@@ -1669,7 +1670,7 @@ int Unit::MaintCost()
 		{
 			if (!(ItemDefs[i].type & IT_MAN)) { continue; }
 
-			if (i == I_LEADERS) { continue; }
+			if (i == I_LEADERS || i == I_FACTIONLEADER) { continue; }
 
 			const int men_in_unit = GetMen(i);
 
@@ -1691,6 +1692,9 @@ void Unit::Short(int needed, int hunger)
 {
 	if (faction->IsNPC())
 		return; // Don't starve monsters and the city guard!
+
+	if (GetMen(I_FACTIONLEADER))
+		return; // FACTION LEADER can't starve
 
 	switch (Globals->SKILL_STARVATION)
 	{


### PR DESCRIPTION
- Added FACTION LEADER man type with 10 hits.  
- Reduced LEADER hits to 5.
- Changed initial faction starting units to 1x FACTION LEADER and 2x LEADER.  
- Reduced initial unit skills.  
- Disabled Flaming Swords.  
- Added Pony and Giant Boar mounts. 
- Added Monster Training to Wood Elf.  
- Added Fishing and removed Hunting from Lizardmen.  
- Added Mining and removed Weaponsmith from Hobgoblins. 
- Reduced power of Wizard Staff and Wizard Robes.  
- Added maximum 25 tax and produce hexes per faction.  
- Reduced wander monster and lair frequency.  
- Enabled weather.  
- Increased city rename cost to 5000.  
- Enabled Abyss level.  
- Increased monster spoil recovery time.  
- Reduced assassin maximum free attacks to 1.  
- Increased number of gates in world.