### PR TITLE
Changed alignment to be explicit (instead of implicit)

### DIFF
--- a/faction.h
+++ b/faction.h
@@ -119,7 +119,8 @@ public:
 	 {
 		 ALL_NEUTRAL,
 		 SOME_EVIL,
-		 SOME_GOOD
+		 SOME_GOOD,
+		 ALIGN_ERROR
 	 };
 
 public:

--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 51 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 52 )
 
 class OrdersCheck
 {

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -667,8 +667,9 @@ int Game::GenRules(const AString &rules, const AString &css,
 			"different strengths and weaknesses will have all the "
 			"weaknesses, and none of the strengths of either race.";
 
-		temp += "Races are categorized as good, neutral, or evil. "
-		    "Your faction may not mix good and evil units.";
+		temp += "Races are categorized as good, neutral, or evil. Your faction"
+		    " may not mix good and evil units. You must DECLARE";
+		temp += " your alignment before buying men that are good or evil.";
 	}
 	f.Paragraph(temp);
 
@@ -4116,11 +4117,16 @@ int Game::GenRules(const AString &rules, const AString &css,
 	f.TagText("H4", "DECLARE [faction] [attitude]");
 	f.TagText("H4", "DECLARE [faction]");
 	f.TagText("H4", "DECLARE DEFAULT [attitude]");
+	f.TagText("H4", "DECLARE ALIGNMENT [good|evil]");
 	temp = "The first form of the DECLARE order sets the attitude of your "
 		"faction towards the given faction.  The second form cancels any "
 		"attitude towards the given faction (so your faction's attitude "
 		"towards that faction will be its default attitude).  The third "
 		"form sets your faction's default attitude.";
+	f.Paragraph(temp);
+	temp = "The fourth form forces your alignment to the given state. This is "
+	    "necessary before you buy men of that particular alignment. Once set, "
+		 "it cannot be changed.";
 	f.Paragraph(temp);
 	f.Paragraph("Examples:");
 	temp = "Declare your faction to be hostile to faction 15.";

--- a/parseorders.cpp
+++ b/parseorders.cpp
@@ -29,6 +29,19 @@
 #include "gamedata.h"
 
 //----------------------------------------------------------------------------
+Faction::Alignments parseAlignment(const AString &str)
+{
+	if (str == "good")
+		return Faction::SOME_GOOD;
+	if (str == "evil")
+		return Faction::SOME_EVIL;
+	if (str == "neutral")
+		return Faction::ALL_NEUTRAL;
+
+	return Faction::ALIGN_ERROR;
+}
+
+//----------------------------------------------------------------------------
 OrdersCheck::OrdersCheck()
 : dummyOrder(NORDERS)
 {
@@ -2164,6 +2177,33 @@ void Game::ProcessDeclareOrder(Faction *f, AString *o, OrdersCheck *pCheck)
 	if (!token)
 	{
 		ParseError(pCheck, 0, f, "DECLARE: No faction given.");
+		return;
+	}
+
+	if (*token == "alignment")
+	{
+		delete token;
+
+		if (f->alignments_ != Faction::ALL_NEUTRAL)
+		{
+			f->Error("DECLARE ALIGNMENT: Your alignment is already set.");
+			return;
+		}
+
+		token = o->gettoken();
+		const Faction::Alignments alignment = parseAlignment(*token);
+
+		if (alignment == Faction::ALIGN_ERROR)
+		{
+			f->Error(AString("DECLARE ALIGNMENT: Invalid value: '") + *token + "'.");
+			delete token;
+			return;
+		}
+		delete token;
+
+		if (!pCheck)
+			f->alignments_ = alignment;
+
 		return;
 	}
 

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -35,9 +35,6 @@
 ///@return true if the man type given by 'manIdx' is compatible with faction alignment 'a'
 bool isAlignCompat(int manIdx, Faction::Alignments a)
 {
-	if (a == Faction::ALL_NEUTRAL)
-		return true;
-
 	const ManType::Alignment ma = ManDefs[manIdx].align;
 	if (ma == ManType::NEUTRAL)
 		return true;
@@ -1540,7 +1537,7 @@ int Game::GetBuyAmount(ARegion * r,Market * m)
 
 						if (!isAlignCompat(ItemDefs[o->item].index, u->faction->alignments_))
 						{
-							u->Error("BUY: Can't mix good and evil men faction-wide.");
+							u->Error("BUY: Can only buy units matching your alignment.");
 							o->num = 0;
 						}
 					}
@@ -1628,17 +1625,6 @@ void Game::DoBuy(ARegion * r,Market * m)
 					{
 						// recruiting; must dilute skills
 						u->AdjustSkills();
-
-						// adjust faction alignment
-						const int mt = ItemDefs[o->item].index;
-						if (ManDefs[mt].align != ManType::NEUTRAL)
-						{
-							if (u->faction->alignments_ == Faction::ALL_NEUTRAL)
-							{
-								u->faction->alignments_ = Faction::Alignments(ManDefs[mt].align);
-							}
-							//else should be compatible
-						}
 					}
 
 					u->items.SetNum(o->item,u->items.GetNum(o->item) + temp);


### PR DESCRIPTION
   Added "DECLARE ALIGNMENT <good|evil>"
   You must issue this command before buying units that are not neutral