### PR TITLE
Fix for PRODUCE messages on errors

### DIFF
--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 59 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 60 )
 
 class OrdersCheck
 {

--- a/monthorders.cpp
+++ b/monthorders.cpp
@@ -775,7 +775,7 @@ bool Game::RunUnitProduce(ARegion *r, Unit *u, ProduceOrder *o, ProduceIntermedi
 	const int input = ItemDefs[o->item].pInput[0].item;
 	if (input == -1)
 	{
-		u->Error(AString("PRODUCE: ") + item.abr + ": can't use multiple PRODUCE commands with raw materials.");
+		u->Error(AString("PRODUCE: ") + item.abr + ": not present in this region.");
 
 		return true;
 	}
@@ -1040,6 +1040,7 @@ void Game::RunProduceOrders(ARegion *r)
 					{
 						// normal PRODUCE order
 						ProduceOrder *o = (ProduceOrder*)u->monthorders;
+
 						const bool ret = RunUnitProduce(r, u, o, &pi);
 						if (ret)
 						{
@@ -1054,6 +1055,20 @@ void Game::RunProduceOrders(ARegion *r)
 						{
 							// peek at first order
 							ProduceOrder *o = &q->orders_[0];
+							const ItemType &item = ItemDefs[o->item];
+							if (item.pInput[0].item == -1)
+							{
+								u->Error(AString("PRODUCE: ") + item.abr + ": can't use multiple PRODUCE commands with raw materials.");
+								q->orders_.pop_front();
+								// if all done
+								if (q->orders_.empty())
+								{
+									delete u->monthorders;
+									u->monthorders = NULL;
+									done = true;
+								}
+								continue;
+							}
 
 							// run it
 							const bool ret = RunUnitProduce(r, u, o, &pi);


### PR DESCRIPTION
   "Multiple produce" only emitted when there are actually multiple produce commands
   "Not present" emitted when raw material is not present