### PR TITLE
Added global flag to disable FIND email command

### DIFF
--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 66 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 67 )
 
 class OrdersCheck
 {

--- a/gamedefs.h
+++ b/gamedefs.h
@@ -439,6 +439,9 @@ public:
 
 	/// If we are preventing sail through, should we also prevent the 'easy portage' that the above allows by default?
 	int ALLOW_TRIVIAL_PORTAGE;
+
+    /// Disable command FIND to allow players to be anonymous, communication is handled elsewhere, etc
+    int DISABLE_FIND_EMAIL_COMMAND;
 };
 
 extern GameDefs *Globals;

--- a/genrules.cpp
+++ b/genrules.cpp
@@ -277,7 +277,9 @@ int Game::GenRules(const AString &rules, const AString &css,
 	f.TagText("LI", f.Link("#exchange", "exchange"));
 	if(Globals->FACTION_LIMIT_TYPE == GameDefs::FACLIM_FACTION_TYPES)
 		f.TagText("LI", f.Link("#faction", "faction"));
-	f.TagText("LI", f.Link("#find", "find"));
+    if (!Globals->DISABLE_FIND_EMAIL_COMMAND) {
+	    f.TagText("LI", f.Link("#find", "find"));
+    }
 	f.TagText("LI", f.Link("#forget", "forget"));
 	f.TagText("LI", f.Link("#form", "form"));
 	f.TagText("LI", f.Link("#give", "give"));
@@ -4264,17 +4266,19 @@ int Game::GenRules(const AString &rules, const AString &css,
 		f.CommandExample(temp, temp2);
 	}
 
-	f.ClassTagText("DIV", "rule", "");
-	f.LinkRef("find");
-	f.TagText("H4", "FIND [faction]");
-	f.TagText("H4", "FIND ALL");
-	temp = "Find the email address of the specified faction or of all "
-		"factions.";
-	f.Paragraph(temp);
-	f.Paragraph("Example:");
-	temp = "Find the email address of faction 4.";
-	temp2 = "FIND 4";
-	f.CommandExample(temp, temp2);
+    if (!Globals->DISABLE_FIND_EMAIL_COMMAND) {
+        f.ClassTagText("DIV", "rule", "");
+        f.LinkRef("find");
+        f.TagText("H4", "FIND [faction]");
+        f.TagText("H4", "FIND ALL");
+        temp = "Find the email address of the specified faction or of all "
+            "factions.";
+        f.Paragraph(temp);
+        f.Paragraph("Example:");
+        temp = "Find the email address of faction 4.";
+        temp2 = "FIND 4";
+        f.CommandExample(temp, temp2);
+    }
 
 	f.ClassTagText("DIV", "rule", "");
 	f.LinkRef("forget");
@@ -5206,8 +5210,10 @@ int Game::GenRules(const AString &rules, const AString &css,
 		temp += f.Link("#weapon", "WEAPON");
 	}
 	temp += " orders are processed.";
-	f.TagText("LI", temp);
-	temp = f.Link("#find", "FIND") + " orders are processed.";
+    if (!Globals->DISABLE_FIND_EMAIL_COMMAND) {
+	    f.TagText("LI", temp);
+	    temp = f.Link("#find", "FIND") + " orders are processed.";
+    }
 	f.TagText("LI", temp);
 	temp = f.Link("#leave", "LEAVE") + " orders are processed.";
 	f.TagText("LI", temp);

--- a/miskatonic/rules.cpp
+++ b/miskatonic/rules.cpp
@@ -198,6 +198,7 @@ static GameDefs g = {
 	50,	// UPKEEP_FOOD_VALUE
 	1,	// PREVENT_SAIL_THROUGH
 	0,	// ALLOW_TRIVIAL_PORTAGE
+    1,  // DISABLE_FIND_EMAIL_COMMAND
 };
 
 GameDefs * Globals = &g;

--- a/runorders.cpp
+++ b/runorders.cpp
@@ -678,6 +678,11 @@ void Game::RunFindUnit(Unit * u)
 	int all = 0;
 	Faction *fac;
 	forlist(&u->findorders) {
+        if (Globals->DISABLE_FIND_EMAIL_COMMAND) {
+            u->Error("FIND: This command has been disabled.");
+            break;
+        }
+
 		FindOrder * f = (FindOrder *) elem;
 		if(f->find == 0) all = 1;
 		if(!all) {


### PR DESCRIPTION
- Added global flag to disable FIND email command.

```
unit 56
find 4

unit 57
find all
```

DISABLE_FIND_EMAIL_COMMAND = 1
```
Errors during turn:
Unit (56): FIND: This command has been disabled.
Unit (57): FIND: This command has been disabled.
```

DISABLE_FIND_EMAIL_COMMAND = 0
```
Events during turn:
The address of Secret Developers (4) is private@secret.com.
The address of The Guardsmen (1) is NoAddress.
The address of Creatures (2) is NoAddress.
The address of Developers (3) is devs@null.com.
The address of Secret Developers (4) is private@secret.com.
```