### PR TITLE
Fixed unit "inheritance" to honor SPOILS flags

### DIFF
--- a/game.h
+++ b/game.h
@@ -41,7 +41,7 @@ class Game;
 #include "object.h"
 #include "orders.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 68 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 69 )
 
 class OrdersCheck
 {

--- a/unit.cpp
+++ b/unit.cpp
@@ -1967,9 +1967,9 @@ int Unit::CanFly(int weight)
 	return (FlyingCapacity() >= weight) ? 1 : 0;
 }
 
-int Unit::CanReallySwim()
+int Unit::CanReallySwim(int weight)
 {
-	return (SwimmingCapacity() >= items.Weight()) ? 1 : 0;
+	return (SwimmingCapacity() >= items.Weight() + weight) ? 1 : 0;
 }
 
 int Unit::CanSwim()

--- a/unit.h
+++ b/unit.h
@@ -327,7 +327,7 @@ public:
 	int CanWalk(int weight);
 	int CanFly();
 	int CanSwim();
-	int CanReallySwim();
+	int CanReallySwim(int weight = 0);
 
 	///@return highest move possible
 	int MoveType();


### PR DESCRIPTION
   When a unit is destroyed, a unit from the same faction "inherits" its items
   The old code just used the first unit in the region.
   Now, all units are available, subject to the value of the flags