### PR TITLE
Added New Building 'Magical Citadel'

### DIFF
--- a/game.h
+++ b/game.h
@@ -26,7 +26,7 @@
 // END A3HEADER
 #include "aregion.h"
 
-#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 70 )
+#define CURRENT_ATL_VER MAKE_ATL_VER( 4, 2, 71 )
 
 class Aorders;
 class ExchangeOrder;

--- a/gamedata.h
+++ b/gamedata.h
@@ -836,6 +836,7 @@ enum ObjectDef
 	O_OASIS,
 	O_GEMAPPRAISER,
 	O_HPTOWER,
+    O_MCITADEL,
 	NOBJECTS
 };
 

--- a/miskatonic/gamedata.cpp
+++ b/miskatonic/gamedata.cpp
@@ -4222,6 +4222,12 @@ static ObjectType ot[] =
 	 I_IRONWOOD,25,-1,0,
 	 25,2,3,
 	 -1,-1},
+	{"Magical Citadel",
+	 ObjectType::NEVERDECAY | ObjectType::CANENTER | ObjectType::CANMODIFY,
+	 1875,0,0,110,
+	 I_ROOTSTONE,640,S_BUILDING,5,
+	 0,0,0,
+	 -1,-1},
 };
 
 ObjectType *const ObjectDefs = ot;

--- a/miskatonic/rules.cpp
+++ b/miskatonic/rules.cpp
@@ -56,7 +56,7 @@ int allowedTradesSize = sizeof(at) / sizeof(at[0]);
 
 static GameDefs g = {
 	"Miskatonic",				// RULESET_NAME
-	MAKE_ATL_VER( 1, 0, 25 ),   // RULESET_VERSION
+	MAKE_ATL_VER( 1, 0, 26 ),   // RULESET_VERSION
 
 	2, /* FOOT_SPEED */
 	4, /* HORSE_SPEED */


### PR DESCRIPTION
This is a magical version of the stone Citadel.

```
Magical Citadel: This is a building. Units may enter this structure.
  This structure provides defense to the first 1875 men inside it.
  This structure is built using building [BUIL] 5 and requires 640
  rootstone to build.
```

```
building [BUIL] 5: A unit with this skill may BUILD the following
  structures: Magical Castle, Magical Citadel.
```